### PR TITLE
Allow interface as handler context [ch10656]

### DIFF
--- a/worker_pool.go
+++ b/worker_pool.go
@@ -386,7 +386,12 @@ func isValidHandlerType(ctxType reflect.Type, vfn reflect.Value) bool {
 			return false
 		}
 	} else if numIn == 2 {
-		if fnType.In(0) != reflect.PtrTo(ctxType) {
+		//if handler context is an interface
+		if fnType.In(0).Kind() == reflect.Interface && !reflect.PtrTo(ctxType).Implements(fnType.In(0)) {
+			return false
+		}
+		//if handler context is not an interface
+		if fnType.In(0).Kind() != reflect.Interface && fnType.In(0) != reflect.PtrTo(ctxType) {
 			return false
 		}
 		if fnType.In(1) != reflect.TypeOf(j) {


### PR DESCRIPTION
`gocraft/work` by default always accepts a concrete Context for each job handler. This makes it difficult to write a generalize handler. Because of concrete Context, we can't use a common handler from a different package e.g. `go-utilities`. We have to copy-paste the same code to each integrations.

This PR makes the Context type as interface. By leveraging interfaces we can now move common code to one place and avoid duplication.