### PR TITLE
Add new queues to worker pool's known jobs [ch17455]

### DIFF
--- a/worker_pool.go
+++ b/worker_pool.go
@@ -176,7 +176,18 @@ func (wp *WorkerPool) JobWithOptions(name string, jobOpts JobOptions, fn interfa
 	if wp.started {
 		wp.writeConcurrencyControlsToRedis(map[string]*jobType{name: jt})
 		wp.mu.Lock()
-		wp.heartbeater.jobNames += "," + name
+		jobNames := strings.Split(wp.heartbeater.jobNames, ",")
+		exists := false
+		for _, job := range jobNames {
+			if job == name {
+				exists = true
+				break
+			}
+		}
+
+		if !exists {
+			wp.heartbeater.jobNames += "," + name
+		}
 		wp.mu.Unlock()
 	}
 


### PR DESCRIPTION
In case of a dirty shutdown, the dead pool reaper [re-enqueues previously running job](https://github.com/gocraft/work/blob/master/dead_pool_reaper.go#L90) to the new pool. But if a queue is created after the worker started, that queue is never registered in the worker pool. So the reaper never finds that job to re-enqueue.