### PR TITLE
Rename go module name to forked version [ch22242]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gocraft/work [![GoDoc](https://godoc.org/github.com/gocraft/work?status.png)](https://godoc.org/github.com/gocraft/work)
+# gocraft/work [![GoDoc](https://godoc.org/github.com/chartmogul/work?status.png)](https://godoc.org/github.com/chartmogul/work)
 
 gocraft/work lets you enqueue and processes background jobs in Go. Jobs are durable and backed by Redis. Very similar to Sidekiq for Go.
 
@@ -21,7 +21,7 @@ package main
 
 import (
 	"github.com/gomodule/redigo/redis"
-	"github.com/gocraft/work"
+	"github.com/chartmogul/work"
 )
 
 // Make a redis pool
@@ -57,7 +57,7 @@ package main
 
 import (
 	"github.com/gomodule/redigo/redis"
-	"github.com/gocraft/work"
+	"github.com/chartmogul/work"
 	"os"
 	"os/signal"
 )
@@ -245,8 +245,8 @@ The web UI provides a view to view the state of your gocraft/work cluster, inspe
 
 Building an installing the binary:
 ```bash
-go get github.com/gocraft/work/cmd/workwebui
-go install github.com/gocraft/work/cmd/workwebui
+go get github.com/chartmogul/work/cmd/workwebui
+go install github.com/chartmogul/work/cmd/workwebui
 ```
 
 Then, you can run it:

--- a/benches/bench_work/main.go
+++ b/benches/bench_work/main.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/gocraft/health"
-	"github.com/gocraft/work"
+	"github.com/chartmogul/work"
 	"github.com/gomodule/redigo/redis"
 )
 

--- a/cmd/workenqueue/main.go
+++ b/cmd/workenqueue/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/gocraft/work"
+	"github.com/chartmogul/work"
 	"github.com/gomodule/redigo/redis"
 )
 

--- a/cmd/workfakedata/main.go
+++ b/cmd/workfakedata/main.go
@@ -6,7 +6,7 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/gocraft/work"
+	"github.com/chartmogul/work"
 	"github.com/gomodule/redigo/redis"
 )
 

--- a/cmd/workwebui/main.go
+++ b/cmd/workwebui/main.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/gocraft/work/webui"
+	"github.com/chartmogul/work/webui"
 	"github.com/gomodule/redigo/redis"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gocraft/work
+module github.com/chartmogul/work
 
 go 1.14
 
@@ -19,7 +19,6 @@ require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/gomodule/redigo v2.0.0+incompatible
 	github.com/jrallison/go-workers v0.0.0-20180112190529-dbf81d0b75bb
-	github.com/jteeuwen/go-bindata v3.0.7+incompatible // indirect
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/orfjackal/nanospec.go v0.0.0-20120727230329-de4694c1d701 // indirect
 	github.com/robfig/cron/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,6 @@ github.com/gomodule/redigo v2.0.0+incompatible h1:K/R+8tc58AaqLkqG2Ol3Qk+DR/TlNu
 github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
 github.com/jrallison/go-workers v0.0.0-20180112190529-dbf81d0b75bb h1:y9LFhCM3gwK94Xz9/h7GcSVLteky9pFHEkP04AqQupA=
 github.com/jrallison/go-workers v0.0.0-20180112190529-dbf81d0b75bb/go.mod h1:ziQRRNHCWZe0wVNzF8y8kCWpso0VMpqHJjB19DSenbE=
-github.com/jteeuwen/go-bindata v3.0.7+incompatible h1:91Uy4d9SYVr1kyTJ15wJsog+esAZZl7JmEfTkwmhJts=
-github.com/jteeuwen/go-bindata v3.0.7+incompatible/go.mod h1:JVvhzYOiGBnFSYRyV00iY8q7/0PThjIYav1p9h5dmKs=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -51,8 +49,6 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/youtube/vitess v2.1.1+incompatible h1:SE+P7DNX/jw5RHFs5CHRhZQjq402EJFCD33JhzQMdDw=
 github.com/youtube/vitess v2.1.1+incompatible/go.mod h1:hpMim5/30F1r+0P8GGtB29d0gWHr0IZ5unS+CG0zMx8=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/net v0.0.0-20200425230154-ff2c4b7c35a0 h1:Jcxah/M+oLZ/R4/z5RzfPzGbPXnVDPkEDtf2JnuxN+U=
-golang.org/x/net v0.0.0-20200425230154-ff2c4b7c35a0/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2 h1:eDrdRpKgkcCqKZQwyZRyeFZgfqt37SL7Kv3tok06cKE=
 golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/webui/webui.go
+++ b/webui/webui.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/braintree/manners"
 	"github.com/gocraft/web"
-	"github.com/gocraft/work"
-	"github.com/gocraft/work/webui/internal/assets"
+	"github.com/chartmogul/work"
+	"github.com/chartmogul/work/webui/internal/assets"
 	"github.com/gomodule/redigo/redis"
 )
 

--- a/webui/webui_test.go
+++ b/webui/webui_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gocraft/work"
+	"github.com/chartmogul/work"
 	"github.com/gomodule/redigo/redis"
 	"github.com/stretchr/testify/assert"
 )


### PR DESCRIPTION
This change will allow us to just reference chartmogul/work module directly across standalone integrations. This will prevent issues with incorrect go module version resolutions. We will also not need to use `replace` and ensure by default that the correct (forked) version is being used. 

One minor downside is that merging upstream updates will be slightly difficult. But that's alright as upstream doesn't have much new development going on. 

I'll update other integrations and go-utilities after merging this.  

https://app.clubhouse.io/chartmogul/story/22242